### PR TITLE
Added regex for Refs and Params

### DIFF
--- a/app/Http/Controllers/ParamController.php
+++ b/app/Http/Controllers/ParamController.php
@@ -73,7 +73,7 @@ class ParamController extends Controller
 
         $this->validate($request, [
             'param' => 'required|array',
-            'param.*' => 'required|string|distinct|max:30',
+            'param.*' => 'required|string|distinct|max:30|regex:/^[a-zA-Z][a-zA-Z0-9]*$/',
             'paramname' => 'required|array',
             'paramname.*' => 'required_with:param.*|string|max:50',
         ]);

--- a/app/Http/Controllers/RefController.php
+++ b/app/Http/Controllers/RefController.php
@@ -67,7 +67,7 @@ class RefController extends Controller
         }
 
         $this->validate($request, [
-            'ref' => 'required|string|max:50|unique:refs,ref,NULL,id,team_id,'.$team->id,
+            'ref' => 'required|string|max:50|regex:/^[a-zA-Z][a-zA-Z0-9]*$/|unique:refs,ref,NULL,id,team_id,'.$team->id,
             'name' => 'required|string|max:100',
         ]);
 

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -98,7 +98,7 @@ return [
     'numeric' => 'The :attribute must be a number.',
     'password' => 'The password is incorrect.',
     'present' => 'The :attribute field must be present.',
-    'regex' => 'The :attribute format is invalid.',
+    'regex' => 'The :attribute format is invalid or has disallowed characters.',
     'required' => 'The :attribute field is required.',
     'required_if' => 'The :attribute field is required when :other is :value.',
     'required_unless' => 'The :attribute field is required unless :other is in :values.',

--- a/resources/lang/pt/validation.php
+++ b/resources/lang/pt/validation.php
@@ -98,7 +98,7 @@ return [
     'numeric' => 'O campo ":attribute" deve ser um número.',
     'password' => 'A palavra-passe está incorreta.',
     'present' => 'O campo ":attribute" deve estar presente.',
-    'regex' => 'O campo ":attribute" tem um formato inválido.',
+    'regex' => 'O campo ":attribute" tem um formato inválido ou carateres não permitidos.',
     'required' => 'O campo ":attribute" é obrigatório.',
     'required_if' => 'O campo ":attribute" é obrigatório quando ":other" for ":value".',
     'required_unless' => 'O campo ":attribute" é obrigatório exceto quando ":other" for ":values".',


### PR DESCRIPTION
Fix for: https://github.com/mripta/dashboard/issues/12
Added regex to only allow numbers and letters when we want to add Params or Refs.
Now symbols will be impossible to use. Also it won't be possible to start the names with numbers.